### PR TITLE
Fix error "EXDEV: cross-device link not permitted"

### DIFF
--- a/__test__/assets/binary.spec.js
+++ b/__test__/assets/binary.spec.js
@@ -47,6 +47,6 @@ describe('verifyAndPlaceBinary()', () => {
 
     verifyAndPlaceBinary('command', './bin', callback);
 
-    expect(fs.renameSync).toHaveBeenCalledWith(path.join('bin', 'command'), path.sep + path.join('usr', 'local', 'bin', 'command'));
+    expect(fs.copyFileSync).toHaveBeenCalledWith(path.join('bin', 'command'), path.sep + path.join('usr', 'local', 'bin', 'command'));
   });
 });

--- a/src/assets/binary.js
+++ b/src/assets/binary.js
@@ -1,5 +1,5 @@
 const { join } = require('path');
-const { existsSync, renameSync, chmodSync } = require('fs');
+const { chmodSync, copyFileSync, existsSync, unlink } = require('fs');
 const { getInstallationPath } = require('../common');
 
 function verifyAndPlaceBinary(binName, binPath, callback) {
@@ -13,7 +13,8 @@ function verifyAndPlaceBinary(binName, binPath, callback) {
       }
 
       // Move the binary file and make sure it is executable
-      renameSync(join(binPath, binName), join(installationPath, binName));
+      copyFileSync(join(binPath, binName), join(installationPath, binName));
+      unlink(join(binPath, binName));
       chmodSync(join(installationPath, binName), '755');
 
       console.log('Placed binary on', join(installationPath, binName));


### PR DESCRIPTION
Had this error with `lerna bootstrap` in starboard-notebook:

```text
Error: EXDEV: cross-device link not permitted, rename 'bin\starlit.exe' -> 'C:\npm\prefix\bin\starlit.exe'
    at renameSync (node:fs:993:3)
    at D:\a\...\starboard-notebook\node_modules\@gzuidhof\go-npm\bin\index.js:2:912145
    at D:\a\...\starboard-notebook\node_modules\@gzuidhof\go-npm\bin\index.js:2:909537
    at ChildProcess.exithandler (node:child_process:390:7)
    at ChildProcess.emit (node:events:527:28)
    at maybeClose (node:internal/child_process:1092:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5) {
  errno: -4037,
  syscall: 'rename',
  code: 'EXDEV',
  path: 'bin\\starlit.exe',
  dest: 'C:\\npm\\prefix\\bin\\starlit.exe'
```

This PR should fix it. I tried the [`mv`](https://www.npmjs.com/package/mv) package but couldn't get the jest tests to pass with the old school JS callback interface – my JS is pretty rubbish.