### PR TITLE
Add {{archive_ext}} to support both ".zip" and ".tar.gz"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * Added support for `arm64` architecture.
 * Fix for use on Windows platform (the binary would get placed in the wrong place for consumers).
 * Shipped as a bundle using `esbuild`, removing 70 packages of dependencies (including huge things like Babel). Now your users will only have to download one additional package (`@gzuidhof/go-npm`).
+* Added `{{archive_ext}}` to recognize `.zip` packages on Windows and `.tar.gz` on macOS and Linux.
 
 ### Distribute cross-platform Go binaries via NPM
 
@@ -92,6 +93,7 @@ Following variables are available to customize the URL:
 * `{{platform}}`: `$GOOS` value for the platform
 * `{{arch}}`: `$GOARCH` value for the architecture
 * `{{win_ext}}`: optional `.exe` extension for windows assets.
+* `{{archive_ext}}`: outputs `.zip` on Windows or `.tar.gz` on macOS and Linux.
 
 If you use `goreleaser` to publish your modules, it will automatically set the right architecture & platform in your URL.
 

--- a/src/common.js
+++ b/src/common.js
@@ -143,8 +143,10 @@ function parsePackageJson() {
     binName += '.exe'
 
     url = url.replace(/{{win_ext}}/g, '.exe');
+    url = url.replace(/{{archive_ext}}/g, '.zip')
   } else {
     url = url.replace(/{{win_ext}}/g, '');
+    url = url.replace(/{{archive_ext}}/g, '.tar.gz')
   }
 
   // Interpolate variables in URL, if necessary


### PR DESCRIPTION
Hi @gzuidhof,

Thanks for your work on this fork! I tried it today for https://github.com/go-task/task and it seems to work great!

I liked the idea to make it a bundle (using `esbuild`) to make it smaller.

I missed one thing to make it fully workable, though. On Task we release `.zip` archives on Windows and `.tar.gz` on the other platforms. This is a common convention on multiples projects. I added support for `{{archive_ext}}` to make it possible for Windows users to use npm to install the tool.